### PR TITLE
add token property

### DIFF
--- a/SimpleImpersonation/Impersonation.cs
+++ b/SimpleImpersonation/Impersonation.cs
@@ -90,6 +90,14 @@ namespace SimpleImpersonation
         }
 
         /// <summary>
+        /// token that represents the specified user
+        /// </summary>
+        public SafeTokenHandle Handle
+        {
+            get { return _handle; }
+        }
+
+        /// <summary>
         /// Disposes the <see cref="Impersonation"/> object, ending impersonation and restoring the original user.
         /// </summary>
         public void Dispose()

--- a/SimpleImpersonation/SafeTokenHandle.cs
+++ b/SimpleImpersonation/SafeTokenHandle.cs
@@ -3,7 +3,10 @@ using Microsoft.Win32.SafeHandles;
 
 namespace SimpleImpersonation
 {
-    internal sealed class SafeTokenHandle : SafeHandleZeroOrMinusOneIsInvalid
+    /// <summary>
+    /// provides a managed wrapper for a token handle
+    /// </summary>
+    public sealed class SafeTokenHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
         internal SafeTokenHandle(IntPtr handle)
             : base(true)
@@ -11,6 +14,7 @@ namespace SimpleImpersonation
             this.handle = handle;
         }
 
+        /// <inheritdoc/>
         protected override bool ReleaseHandle()
         {
             return NativeMethods.CloseHandle(handle);


### PR DESCRIPTION
#### Summary
This PR makes the SafeTokenHandle public, so it can be reused in subsequent calls.

#### Use Case
I need to start an impersonated process from a service running as SYSTEM. This is not possible with `System.Diagnostics.Process` since it uses [CreateProcessWithLogonW](https://referencesource.microsoft.com/#System/services/monitoring/system/diagnosticts/Process.cs,2085).
> You cannot call CreateProcessWithLogonW from a process that is running under the "LocalSystem" account, because the function uses the logon SID in the caller token, and the token for the "LocalSystem" account does not contain this SID. As an alternative, use the [CreateProcessAsUser](https://msdn.microsoft.com/en-us/library/windows/desktop/ms682429(v=vs.85).aspx) and [LogonUser](https://msdn.microsoft.com/en-us/library/windows/desktop/aa378184(v=vs.85).aspx) functions.

`CreateProcessAsUser` requires the token, which is returned from `LogonUser`.