### PR TITLE
Made test principal id more discriminating.

### DIFF
--- a/test/SimpleImpersonation.UnitTests/UserPrincipalFixture.cs
+++ b/test/SimpleImpersonation.UnitTests/UserPrincipalFixture.cs
@@ -18,7 +18,7 @@ namespace SimpleImpersonation.UnitTests
 
         public UserPrincipalFixture()
         {
-            Username = "Test" + DateTime.Now.ToString("yyyyMMdd'T'HHmmss");
+            Username = "Test" + DateTime.Now.ToString("HHmmssffffff");
             Password = Guid.NewGuid().ToString();
 
             var ss = new SecureString();


### PR DESCRIPTION
On my machine I get failed tests because a test principal with the generated name already exists.
Resolution at seconds level apparently is not fine grained enough. 

Changed generated name to use second fractions, discriminating on a microsecond level.